### PR TITLE
Fix: Update Videos link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@
                     <ul class="footer-links">
                         <li><a href="#about">About Us</a></li>
                         <li><a href="#learn">What You'll Learn</a></li>
-                        <li><a href="#videos">Videos</a></li>
+                        <li><a href="https://www.youtube.com/@fundamentalstockanalysis/videos">Videos</a></li>
                         <li><a href="#podcast">Podcast</a></li>
                         <li><a href="#connect">Connect</a></li>
                     </ul>


### PR DESCRIPTION
### **User description**
The "Videos" link in the footer's quick links section now correctly points to https://www.youtube.com/@fundamentalstockanalysis/videos.


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the "Videos" link in the footer to point to the correct YouTube URL.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Update footer "Videos" link to external YouTube</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<li>Changed the "Videos" link in the footer from an internal anchor to an <br>external YouTube URL.


</details>


  </td>
  <td><a href="https://github.com/care-filledsupportformeg/fundamentalstockanalysis/pull/1/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>